### PR TITLE
Potential fix for code scanning alert no. 3: Use of externally-controlled format string

### DIFF
--- a/server/services/user_service.js
+++ b/server/services/user_service.js
@@ -447,7 +447,7 @@ class UserService {
         await deleteImageFromImgBB(user.imgbbDeleteUrl);
         console.log(`Profile picture deleted from ImgBB for user ${id}: ${user.imgbbDeleteUrl}`);
       } catch (error) {
-        console.error(`Failed to delete profile picture from ImgBB for user ${id} (might already be gone or URL expired):`, error.message);
+        console.error('Failed to delete profile picture from ImgBB for user %s (might already be gone or URL expired): %s', id, error.message);
         // Aquí decides si lanzas un error Boom o simplemente loggeas y continuas.
         // Generalmente, no quieres que la eliminación del usuario falle solo porque la imagen no se borró de ImgBB.
       }


### PR DESCRIPTION
Potential fix for [https://github.com/JesusAraujoDEV/mediart/security/code-scanning/3](https://github.com/JesusAraujoDEV/mediart/security/code-scanning/3)

To fix the issue, the untrusted `id` parameter should not be directly interpolated into the format string. Instead, the `%s` specifier should be used in the format string, and the `id` value should be passed as a separate argument. This ensures that the format string is controlled and prevents any unintended behavior caused by malicious input.

#### Steps to implement the fix:
1. Modify the `console.error` statement on line 450 of `server/services/user_service.js` to use a controlled format string with `%s` specifiers.
2. Pass the `id` parameter as a separate argument to the `console.error` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
