### PR TITLE
Potential fix for code scanning alert no. 1: Use of externally-controlled format string

### DIFF
--- a/server/services/playlist_service.js
+++ b/server/services/playlist_service.js
@@ -327,7 +327,7 @@ class PlaylistService {
         await deleteImageFromImgBB(playlist.imgbbDeleteUrl);
         console.log(`ImgBB playlist cover deleted for playlist ${id} on playlist deletion.`);
       } catch (error) {
-        console.error(`Failed to delete ImgBB playlist cover for playlist ${id}:`, error);
+        console.error('Failed to delete ImgBB playlist cover for playlist %s:', id, error);
         // No impedimos la eliminación de la playlist si falla la eliminación de la imagen
       }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/JesusAraujoDEV/mediart/security/code-scanning/1](https://github.com/JesusAraujoDEV/mediart/security/code-scanning/1)

To fix the issue, we will sanitize the untrusted `id` parameter before using it in the `console.error` statement. Instead of directly interpolating the `id` into the template string, we will use a `%s` specifier in the format string and pass the `id` as a separate argument. This approach ensures that the `id` is treated as a string and prevents any unintended format specifiers from being processed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
