### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/server/middlewares/auth_handler.js
+++ b/server/middlewares/auth_handler.js
@@ -8,7 +8,7 @@ function checkMasterApiKey(req, res, next) {
     const apiKey = req.headers['x-api-key'] || req.query.api_key;
     
     console.log('API Key recibida:', apiKey);
-    console.log('API Key configurada:', config.apiKey);
+    console.log('API Key configurada: [REDACTED]');
     console.log('¿Coinciden las API Keys?', apiKey === config.apiKey);
 
     if (config.apiKey && apiKey === config.apiKey) {


### PR DESCRIPTION
Potential fix for [https://github.com/JesusAraujoDEV/mediart/security/code-scanning/10](https://github.com/JesusAraujoDEV/mediart/security/code-scanning/10)

To fix the problem, we should remove or redact the logging of sensitive information. Specifically, on line 11, instead of logging the actual value of `config.apiKey`, we can log that the API key is configured (e.g., "API Key configurada: [REDACTED]") or omit the log entirely. This preserves the ability to debug without exposing the actual secret. The same principle applies to any other logs that might expose sensitive data, but in this case, only line 11 is flagged. No new imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
