### PR TITLE
Potential fix for code scanning alert no. 12: Clear-text logging of sensitive information

### DIFF
--- a/server/middlewares/auth_handler.js
+++ b/server/middlewares/auth_handler.js
@@ -7,7 +7,7 @@ const passport = require('passport');
 function checkMasterApiKey(req, res, next) {
     const apiKey = req.headers['x-api-key'] || req.query.api_key;
     
-    console.log('API Key recibida:', apiKey);
+    console.log('API Key recibida: [REDACTED]');
     console.log('API Key configurada: [REDACTED]');
     console.log('¿Coinciden las API Keys?', apiKey === config.apiKey);
 


### PR DESCRIPTION
Potential fix for [https://github.com/JesusAraujoDEV/mediart/security/code-scanning/12](https://github.com/JesusAraujoDEV/mediart/security/code-scanning/12)

To fix the problem, we should ensure that sensitive information such as API keys is never logged in clear text. The best approach is to either remove the log statement entirely or, if logging is necessary for debugging, redact or mask the sensitive value before logging. In this case, we will redact the API key in the log output, replacing it with a fixed string such as `[REDACTED]` or by masking all but the last few characters. This change should be made only to the relevant log statement in `server/middlewares/auth_handler.js` on line 10. No new imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
