### PR TITLE
Potential fix for code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/client/components/sections/Library.vue
+++ b/client/components/sections/Library.vue
@@ -291,7 +291,13 @@ const handleImageError = (event: Event) => {
   const img = event.target as HTMLImageElement
   if (!img) return
   const alt = img.getAttribute('data-alt-src') || ''
-  if (alt && img.src !== alt) {
+  // Only allow safe URLs (http, https, or relative paths not starting with dangerous schemes)
+  const isSafeUrl = alt && (
+    alt.startsWith('http://') ||
+    alt.startsWith('https://') ||
+    (/^[/.a-zA-Z0-9_-]+$/.test(alt) && !alt.startsWith('javascript:') && !alt.startsWith('data:'))
+  )
+  if (isSafeUrl && img.src !== alt) {
     img.src = alt
     img.setAttribute('data-alt-src', '')
     return

--- a/client/components/sections/Library.vue
+++ b/client/components/sections/Library.vue
@@ -295,7 +295,7 @@ const handleImageError = (event: Event) => {
   const isSafeUrl = alt && (
     alt.startsWith('http://') ||
     alt.startsWith('https://') ||
-    (/^[/.a-zA-Z0-9_-]+$/.test(alt) && !alt.startsWith('javascript:') && !alt.startsWith('data:'))
+    (/^[/.a-zA-Z0-9_-]+$/.test(alt) && !alt.startsWith('javascript:') && !alt.startsWith('data:') && !alt.startsWith('vbscript:'))
   )
   if (isSafeUrl && img.src !== alt) {
     img.src = alt


### PR DESCRIPTION
Potential fix for [https://github.com/JesusAraujoDEV/mediart/security/code-scanning/11](https://github.com/JesusAraujoDEV/mediart/security/code-scanning/11)

To fix this vulnerability, we must ensure that the value assigned to `img.src` is safe and cannot be used to execute JavaScript or load malicious content. The best way to do this is to validate the value of `alt` before assigning it to `img.src`. Specifically, we should only allow URLs that start with `http://`, `https://`, or are relative paths (not starting with `javascript:`, `data:`, etc.). This can be done by checking the value of `alt` and only assigning it if it matches a safe pattern. If the value is not safe, we should fall back to a known safe placeholder image.

The change should be made in the `handleImageError` function in `client/components/sections/Library.vue`, specifically around lines 293-295. No new imports are needed; a simple validation function or regex can be used inline.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
