### PR TITLE
Potential fix for code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/client/components/sections/Library.vue
+++ b/client/components/sections/Library.vue
@@ -299,7 +299,10 @@ const handleImageError = (event: Event) => {
       const url = new URL(alt, window.location.origin);
       if (url.protocol === 'http:' || url.protocol === 'https:') {
         isSafeUrl = true;
-      } else if (url.origin === window.location.origin && !alt.trim().toLowerCase().startsWith('javascript:') && !alt.trim().toLowerCase().startsWith('data:') && !alt.trim().toLowerCase().startsWith('vbscript:')) {
+      } else if (
+        url.origin === window.location.origin &&
+        !/^(\s*)(javascript:|data:|vbscript:)/i.test(alt)
+      ) {
         isSafeUrl = true;
       }
     } catch (e) {

--- a/client/components/sections/Library.vue
+++ b/client/components/sections/Library.vue
@@ -292,11 +292,21 @@ const handleImageError = (event: Event) => {
   if (!img) return
   const alt = img.getAttribute('data-alt-src') || ''
   // Only allow safe URLs (http, https, or relative paths not starting with dangerous schemes)
-  const isSafeUrl = alt && (
-    alt.startsWith('http://') ||
-    alt.startsWith('https://') ||
-    (/^[/.a-zA-Z0-9_-]+$/.test(alt) && !alt.startsWith('javascript:') && !alt.startsWith('data:') && !alt.startsWith('vbscript:'))
-  )
+  let isSafeUrl = false;
+  if (alt) {
+    try {
+      // Allow only http(s) URLs or relative URLs that do not start with dangerous schemes
+      const url = new URL(alt, window.location.origin);
+      if (url.protocol === 'http:' || url.protocol === 'https:') {
+        isSafeUrl = true;
+      } else if (url.origin === window.location.origin && !alt.trim().toLowerCase().startsWith('javascript:') && !alt.trim().toLowerCase().startsWith('data:') && !alt.trim().toLowerCase().startsWith('vbscript:')) {
+        isSafeUrl = true;
+      }
+    } catch (e) {
+      // Invalid URL, do not allow
+      isSafeUrl = false;
+    }
+  }
   if (isSafeUrl && img.src !== alt) {
     img.src = alt
     img.setAttribute('data-alt-src', '')


### PR DESCRIPTION
Potential fix for [https://github.com/JesusAraujoDEV/mediart/security/code-scanning/11](https://github.com/JesusAraujoDEV/mediart/security/code-scanning/11)

To fix this problem, we should ensure that the value read from `data-alt-src` is strictly validated before being assigned to `img.src`. The current checks are a good start, but we can improve them by:

- Only allowing absolute URLs with `http` or `https` schemes, or strictly validated relative URLs.
- Avoiding the use of regular expressions that may be too permissive.
- Using the browser's URL API to parse and validate URLs, which is more robust than string checks.
- Optionally, only allowing URLs from the same origin or a whitelist of trusted domains.

The best fix is to replace the current `isSafeUrl` logic with a more robust check using the `URL` constructor, and to ensure that only URLs that are either absolute with `http(s)` or relative (not starting with `/`, `\`, or `.`) are allowed. This should be done in the `handleImageError` function in `client/components/sections/Library.vue`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
